### PR TITLE
Support ufloat and generic types

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
 
+    - name: Install testing packages
+      run: pip install uncertainties
+
     - name: Test electronvolt
       run: python -B tests.py
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
 
+    - name: Install testing packages
+      run: pip install uncertainties
+
     - name: Test electronvolt
       run: python tests.py

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A physics quantity calculator with units.
 0.5109989499961642
 ```
 
-This matches the rest energy of electron on [Wikipedia](https://en.wikipedia.org/wiki/Electron_rest_mass).
+This matches the electron rest energy on [Wikipedia](https://en.wikipedia.org/wiki/Electron_rest_mass).
 
 **Rest mass of an electron, with [uncertainties](https://github.com/lebigot/uncertainties)**
 
@@ -49,7 +49,7 @@ This matches the rest energy of electron on [Wikipedia](https://en.wikipedia.org
 (8.1871057768+/-0.0000000025)e-14 * kg * s**-2 * m**2
 ```
 
-This matches the rest energy of electron with uncertainties on the same Wikipedia page.
+This matches the electron rest energy, with uncertainties, on the same Wikipedia page.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A physics quantity calculator with units.
 **Rest mass of an electron**
 
 ```
+>>> from electronvolt import *
 >>> me
 9.1093837015e-31 * kg
 ```
@@ -31,6 +32,24 @@ A physics quantity calculator with units.
 ```
 
 This matches the rest energy of electron on [Wikipedia](https://en.wikipedia.org/wiki/Electron_rest_mass).
+
+**Rest mass of an electron, with [uncertainties](https://github.com/lebigot/uncertainties)**
+
+```
+>>> from uncertainties import ufloat
+>>> ume = ufloat(9.1093837015, 0.0000000028) * 1e-31 * kg
+>>> ume
+(9.1093837015+/-0.0000000028)e-31 * kg
+```
+
+**Rest energy of an electron, in SI units, with uncertainties**
+
+```
+>>> ume * c**2
+(8.1871057768+/-0.0000000025)e-14 * kg * s**-2 * m**2
+```
+
+This matches the rest energy of electron with uncertainties on the same Wikipedia page.
 
 ## Usage
 

--- a/electronvolt.py
+++ b/electronvolt.py
@@ -46,6 +46,7 @@ class Quantity:
     def __init__(self, value, unit):
         self.value = value
         self.unit = unit
+        assert self.unit # not dimensionless
 
     def __repr__(self):
         if not self.unit:
@@ -124,7 +125,7 @@ class Quantity:
 # wrapper
 
 def quantity(value, unit=None, **d):
-    unit = unit if isinstance(unit, Unit) else Unit(d) # unit must be Unit type
+    unit = unit if isinstance(unit, Unit) else Unit(d) # enforce Unit type
     if not unit:
         return value # value can be any type
     return Quantity(value, unit)
@@ -314,7 +315,7 @@ pc = au / radians(1/3600) # parsec
 Mpc = mega * pc # megaparsec
 H0 = 72 * km/s / Mpc # Hubble parameter
 
-# print constant table at import
+# table of constants
 
 table = ''
 for v, q in globals().copy().items():
@@ -358,5 +359,3 @@ for v, q in globals().copy().items():
         elif v == 'G':
             table += '\nCosmology\n'
         table += f'{v:<15}{q.value:<25.9g}{q.unit}\n'
-
-print(table)

--- a/electronvolt.py
+++ b/electronvolt.py
@@ -43,9 +43,9 @@ class Unit:
 
 class Quantity:
 
-    def __init__(self, value, unit=None, **d):
+    def __init__(self, value, unit):
         self.value = value
-        self.unit = unit if isinstance(unit, Unit) else Unit(d)
+        self.unit = unit
 
     def __repr__(self):
         if not self.unit:
@@ -54,7 +54,7 @@ class Quantity:
 
     def __eq__(self, other):
         if not isinstance(other, Quantity): # not considering 0*kg == 0
-            other = Quantity(other)
+            return False # Quantity != dimensionless
         return self.value == other.value and self.unit == other.unit
 
     def __lt__(self, other):
@@ -74,44 +74,42 @@ class Quantity:
         return self.value >= other.value
 
     def __add__(self, other):
-        if not isinstance(other, Quantity): # handles 1*kg/kg + 1
-            other = Quantity(other)
+        assert isinstance(other, Quantity), f"Addition undefined between '{self.unit}' and ''"
         assert self.unit == other.unit, f"Addition undefined between '{self.unit}' and '{other.unit}'"
-        return Quantity(self.value + other.value, self.unit)
+        return quantity(self.value + other.value, self.unit)
 
     def __radd__(self, other):
         return self + other
 
     def __sub__(self, other):
-        if not isinstance(other, Quantity): # handles 1*kg/kg - 1
-            other = Quantity(other)
+        assert isinstance(other, Quantity), f"Subtraction undefined between '{self.unit}' and ''"
         assert self.unit == other.unit, f"Subtraction undefined between '{self.unit}' and '{other.unit}'"
-        return Quantity(self.value - other.value, self.unit)
+        return quantity(self.value - other.value, self.unit)
 
     def __rsub__(self, other): # calls __neg__
         return -(self - other) # self.__rsub__(other) becomes -self.__sub__(other)
 
     def __neg__(self):
-        return Quantity(-self.value, self.unit)
+        return quantity(-self.value, self.unit)
 
     def __mul__(self, other): # both kg*10 and kg*m works
         if not isinstance(other, Quantity):
-            other = Quantity(other)
-        return Quantity(self.value * other.value, self.unit * other.unit)
+            return quantity(self.value * other, self.unit)
+        return quantity(self.value * other.value, self.unit * other.unit)
 
     def __rmul__(self, other): # handles 10*kg
         return self * other
 
     def __truediv__(self, other):
         if not isinstance(other, Quantity):
-            other = Quantity(other)
-        return Quantity(self.value / other.value, self.unit / other.unit)
+            return quantity(self.value / other, self.unit)
+        return quantity(self.value / other.value, self.unit / other.unit)
 
     def __rtruediv__(self, other):
         return (self / other) ** -1
 
     def __pow__(self, exponent):
-        return Quantity(self.value ** exponent, self.unit ** exponent)
+        return quantity(self.value ** exponent, self.unit ** exponent)
 
     def __rpow__(self, base): # handles euler ** (1*s/s)
         assert not self.unit, f"Exponent cannot have unit '{self.unit}'"
@@ -123,13 +121,13 @@ class Quantity:
     def __bool__(self):
         return bool(self.value)
 
-    def __float__(self): # handles exp(1*s/s)
-        assert not self.unit, f"Conversion undefined from '{self.unit}' to ''"
-        return float(self.value)
+# wrapper
 
-    def __complex__(self):
-        assert not self.unit, f"Conversion undefined from '{self.unit}' to ''"
-        return complex(self.value)
+def quantity(value, unit=None, **d):
+    unit = unit if isinstance(unit, Unit) else Unit(d) # unit must be Unit type
+    if not unit:
+        return value # value can be any type
+    return Quantity(value, unit)
 
 # trigonometric functions
 
@@ -204,13 +202,13 @@ trillion = tera
 
 # units and constants
 
-s = Quantity(1, s=1)
-m = Quantity(1, m=1)
-kg = Quantity(1, kg=1)
-A = Quantity(1, A=1)
-K = Quantity(1, K=1)
-mol = Quantity(1, mol=1)
-cd = Quantity(1, cd=1)
+s = quantity(1, s=1)
+m = quantity(1, m=1)
+kg = quantity(1, kg=1)
+A = quantity(1, A=1)
+K = quantity(1, K=1)
+mol = quantity(1, mol=1)
+cd = quantity(1, cd=1)
 
 minute = 60 * s
 hour = 60 * minute

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="electronvolt",
-    version="1.4.4",
+    version="1.5.0",
     author_email="lw7jz@virginia.edu",
     description="A physics quantity calculator with units.",
     long_description=long_description,

--- a/tests.py
+++ b/tests.py
@@ -1,11 +1,14 @@
 from electronvolt import *
+from uncertainties import ufloat
 
 assert c == 299792458 * m / s
 assert euler ** (1 * s / s) == exp(1 * kg / kg)
 assert cos(-pi) == -1
 assert 12 != 12 * kg
 assert 2 == 1 * kg / kg + 1
-assert Quantity(6, kg=5, mol=-2) == 6 * kg**5 / mol**2
+assert quantity(6, kg=5, mol=-2) == 6 * kg**5 / mol**2
+assert not isinstance(ufloat(3, 1) * km / m, Quantity)
+assert isinstance(alpha, float)
 
 assert 1 * m != 1 * s
 assert 2 * kg + kg * 2 <= 5 * kg

--- a/tests.py
+++ b/tests.py
@@ -1,13 +1,15 @@
 from electronvolt import *
 from uncertainties import ufloat
 
+print(table)
+
 assert c == 299792458 * m / s
 assert euler ** (1 * s / s) == exp(1 * kg / kg)
 assert cos(-pi) == -1
 assert 12 != 12 * kg
 assert 2 == 1 * kg / kg + 1
 assert quantity(6, kg=5, mol=-2) == 6 * kg**5 / mol**2
-assert not isinstance(ufloat(3, 1) * km / m, Quantity)
+assert not isinstance(ufloat(3, 1) * km / ly, Quantity)
 assert isinstance(alpha, float)
 
 assert 1 * m != 1 * s


### PR DESCRIPTION
`Quantity(value, unit)`, where `value` could now be anything. Previously it can only be `int`, `float`, or `complex`. Still, enforcing `unit` to be `Unit` type.

Too much abstract algebra for me lol

Also completes #3